### PR TITLE
コメント機能のエラーメッセージを正しく表示させる

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -54,11 +54,7 @@
             <%= form_with(model: [@article, @comment], data: { remote: true }, class: "comment__form") do |f| %>
                 <div class="comment__area">
                     <div id="comment_error">
-                        <% if @comment.errors.any? %>
-                            <p class="comment__area--error settings__form--errors" >
-                                <%= @comment.errors.full_messages.first %>
-                            </p>
-                        <% end %>
+                        <%= render "shared/comment_error" %>
                     </div>
                     <%= f.text_area :content, placeholder: "140文字以内", class: "comment__area--text_area" %>
                 </div>

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,4 +1,4 @@
 document.getElementById('comment_ajax').innerHTML = '<%= j(render "shared/comment") %>';
 document.getElementById('comment_count_ajax').innerHTML = '<%= j("#{@comments.count}件") %>';
-document.getElementById('comment_error').innerHTML = '<p class="comment__area--error settings__form--errors" ><%= j(@comment.errors.full_messages.first) %></p>';
+document.getElementById('comment_error').innerHTML = '<%= j(render "shared/comment_error") %>';
 document.getElementById('comment_content').value = '';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,10 +43,8 @@
     <!-- ヘッダー -->
     <%= render 'shared/header' %>
     <!-- flashメッセージ -->
-    <% unless flash[:comment_error] %>
-      <% flash.each do |message_class, message| %>
-        <p class="flash flash_<%= message_class %>"><%= message %></p>
-      <% end %>
+    <% flash.each do |message_class, message| %>
+      <p class="flash flash_<%= message_class %>"><%= message %></p>
     <% end %>
     <!-- main -->
     <main>

--- a/app/views/shared/_comment_error.html.erb
+++ b/app/views/shared/_comment_error.html.erb
@@ -1,0 +1,5 @@
+<% if @comment.errors.any? %>
+    <p class="comment__area--error settings__form--errors" id="comment_error">
+        <%= @comment.errors.full_messages.first %>
+    </p>
+<% end %>


### PR DESCRIPTION
コメント機能のエラーメッセージを正しく表示させました。

render内で条件分岐することで解決しました。