### PR TITLE
unicornをkillできない

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -12,15 +12,20 @@ timeout timeout
 listen  listen
 pid pid
 preload_app true
+run_once = true
 
 before_fork do |server, worker|
-  defined?(ActiveRecord::Base) and ActiveRecord::Base.connection.disconnect!
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.connection.disconnect!
+  if run_once
+    run_once = false
+  end
   old_pid = "#{server.config[:pid]}.oldbin"
-  if old_pid != server.pid
+  if File.exist?(old_pid) && server.pid != old_pid
     begin
-      Process.kill "QUIT", File.read(old_pid).to_i
-    rescue Errno::ENOENT, Errno::ESRCH
-      return
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH => e
+      logger.error e
     end
   end
 end


### PR DESCRIPTION
unicornをkillできない問題を解決するため、unicorn.conf.rbを編集しました。

具体的には、例外処理をきちんと記述しました。