### PR TITLE
require capistrano/scm/gitをコメントアウトする

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -17,8 +17,8 @@ require 'capistrano/rails/migrations'
 # require "capistrano/scm/svn"
 # install_plugin Capistrano::SCM::Svn
 # or
-require "capistrano/scm/git"
-install_plugin Capistrano::SCM::Git
+# require "capistrano/scm/git"
+# install_plugin Capistrano::SCM::Git
 
 # Include tasks from other gems included in your Gemfile
 #
@@ -40,4 +40,4 @@ install_plugin Capistrano::SCM::Git
 # require "capistrano/passenger"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
-Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+Dir.glob('lib/capistrano/tasks/*.rb').each { |r| import r }


### PR DESCRIPTION
require capistrano/scm/gitをコメントアウトしました。

またtaskを記述したファイルを読み込むため、Dir.glob('lib/capistrano/tasks/*.rb')の拡張子をrbに変更しました。